### PR TITLE
provider/aws: Fix issue when protocol = -1 in aws_security_group_rule

### DIFF
--- a/website/source/docs/providers/aws/r/security_group_rule.html.markdown
+++ b/website/source/docs/providers/aws/r/security_group_rule.html.markdown
@@ -45,7 +45,8 @@ or `egress` (outbound).
 * `prefix_list_ids` - (Optional) List of prefix list IDs (for allowing access to VPC endpoints).
 Only valid with `egress`.
 * `from_port` - (Required) The start port (or ICMP type number if protocol is "icmp").
-* `protocol` - (Required) The protocol. If not icmp, tcp, udp, or all use the [protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
+* `protocol` - (Required) The protocol. If you select a protocol of
+"-1", you must specify a "from_port" and "to_port" equal to 0. If not icmp, tcp, udp, or all use the [protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
 * `security_group_id` - (Required) The security group to apply this rule to.
 * `source_security_group_id` - (Optional) The security group id to allow access to/from,
      depending on the `type`. Cannot be specified with `cidr_blocks`.


### PR DESCRIPTION
In the case of aws_security_group, if protocol = -1 and a port number
other than 0 is specified, an error occurs during terraform apply. This
is a workaround for AWS to ignore port numbers with protocol = -1.
(refs: https://github.com/hashicorp/terraform/pull/1798)

However, aws_security_group_rule does not have this check and behavior
is inconsistent.
aws_security_group_rule should have the same check.